### PR TITLE
Prefer the use of COPY to ADD for security purposes.

### DIFF
--- a/aarch64/Dockerfile
+++ b/aarch64/Dockerfile
@@ -1,3 +1,3 @@
 FROM scratch
-ADD alpine-minirootfs-3.10.3-aarch64.tar.gz /
+COPY alpine-minirootfs-3.10.3-aarch64.tar.gz /
 CMD ["/bin/sh"]

--- a/armhf/Dockerfile
+++ b/armhf/Dockerfile
@@ -1,3 +1,3 @@
 FROM scratch
-ADD alpine-minirootfs-3.10.3-armhf.tar.gz /
+COPY alpine-minirootfs-3.10.3-armhf.tar.gz /
 CMD ["/bin/sh"]

--- a/armv7/Dockerfile
+++ b/armv7/Dockerfile
@@ -1,3 +1,3 @@
 FROM scratch
-ADD alpine-minirootfs-3.10.3-armv7.tar.gz /
+COPY alpine-minirootfs-3.10.3-armv7.tar.gz /
 CMD ["/bin/sh"]

--- a/ppc64le/Dockerfile
+++ b/ppc64le/Dockerfile
@@ -1,3 +1,3 @@
 FROM scratch
-ADD alpine-minirootfs-3.10.3-ppc64le.tar.gz /
+COPY alpine-minirootfs-3.10.3-ppc64le.tar.gz /
 CMD ["/bin/sh"]

--- a/s390x/Dockerfile
+++ b/s390x/Dockerfile
@@ -1,3 +1,3 @@
 FROM scratch
-ADD alpine-minirootfs-3.10.3-s390x.tar.gz /
+COPY alpine-minirootfs-3.10.3-s390x.tar.gz /
 CMD ["/bin/sh"]

--- a/x86/Dockerfile
+++ b/x86/Dockerfile
@@ -1,3 +1,3 @@
 FROM scratch
-ADD alpine-minirootfs-3.10.3-x86.tar.gz /
+COPY alpine-minirootfs-3.10.3-x86.tar.gz /
 CMD ["/bin/sh"]

--- a/x86_64/Dockerfile
+++ b/x86_64/Dockerfile
@@ -1,3 +1,3 @@
 FROM scratch
-ADD alpine-minirootfs-3.10.3-x86_64.tar.gz /
+COPY alpine-minirootfs-3.10.3-x86_64.tar.gz /
 CMD ["/bin/sh"]


### PR DESCRIPTION
The rationale is:

COPY instruction just copies the files from the local host machine to the container file system. ADD instruction potentially could retrieve files from remote URLs and perform operations such as unpacking. Thus, ADD instruction introduces risks such as adding malicious files from URLs without scanning and unpacking procedure vulnerabilities.