### PR TITLE
Execute "docker run" without interactive TTY

### DIFF
--- a/prepare-branch.sh
+++ b/prepare-branch.sh
@@ -16,7 +16,7 @@ prepare() {
 	docker build -t docker-brew-alpine-fetch .
 	docker run \
 		${MIRROR+ -e "MIRROR=$MIRROR"} \
-		--user $(id -u) --rm -it \
+		--user $(id -u) --rm \
 		-v $dir:/out \
 		docker-brew-alpine-fetch $branch /out
 	echo "=> Verifying checksums"


### PR DESCRIPTION
Fixes #120 by removing the `-it` flags for `docker run` in the preparation step. This should have no negative consequences as the executed image does not require any interaction.