### PR TITLE
Add /etc/entrypoint.d entrypoint logic to docker images.

### DIFF
--- a/tests/common.bats
+++ b/tests/common.bats
@@ -62,3 +62,7 @@ setup() {
   docker rm $container
 }
 
+@test "entrypoints in /etc/entrypoint.d should run" {
+  r="$(docker run --rm -v $(pwd)/tests/entrypoint.sh:/etc/entrypoint.d/hello alpine:$TAG)"
+  [ "$r" = "hello from entrypoint" ]
+}

--- a/tests/entrypoint.sh
+++ b/tests/entrypoint.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+echo 'hello from entrypoint'


### PR DESCRIPTION
This allows hooking the base image without having to duplicate logic in $n containers, useful for simple tasks such as user creation, chmod, etc.