### PR TITLE
github: add issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Package-specific issues
+    url: https://gitlab.alpinelinux.org/alpine/aports/-/issues
+    about: For a single or multiple packages, and not specific to containers
+  - name: Community support
+    url: https://alpinelinux.org/community/
+    about: If you need help and or have support questions


### PR DESCRIPTION
That people get redirected to the right places to ask questions.

You can try it out at https://github.com/fossdd/docker-alpine/issues/new/choose