### PR TITLE
Add containerexec user for app execution

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
 FROM alpine:3.16
+RUN adduser -S -H -h / -g "Container Execution User" --shell /usr/sbin/nologin containerexec
 RUN apk add --no-cache lua5.3 lua-filesystem lua-lyaml lua-http
 COPY fetch-latest-releases.lua /usr/local/bin
 VOLUME /out


### PR DESCRIPTION
I think it would be helpful to provide a user intended for app execution in the base image. Best practice dictates that production containers should not be deployed using the root user for app execution. Currently this leaves it to each app owner to create an unprivileged user in their app Dockerfile or maintain a base image with the same. My suggestion is to create a system user that app owners leverage knowing that this user is maintained to adhere to best practices in the base image.