### PR TITLE
switch ADD to COPY per docker best practices https://docs.docker.com/…

### DIFF
--- a/fetch-latest-releases.lua
+++ b/fetch-latest-releases.lua
@@ -59,7 +59,7 @@ function m.mkdockerfile(dir, rootfsfile)
 	if not f then
 		m.fatal("Error: %s: %s", filename, err)
 	end
-	f:write(string.format('FROM scratch\nADD %s /\nCMD ["/bin/sh"]\n', rootfsfile))
+	f:write(string.format('FROM scratch\nCOPY %s /\nCMD ["/bin/sh"]\n', rootfsfile))
 	f:close()
 end
 


### PR DESCRIPTION
As the files have already been downloaded:

```
...
    m.fetch_file(url, string.format("%s/%s", archdir, img.file))
    m.mkdockerfile(archdir, img.file)
```

Using the COPY command here instead of ADD (per docker best practices) makes more sense.

https://docs.docker.com/build/building/best-practices/#add-or-copy
